### PR TITLE
Fix wasm build by replacing a cfg(not(windows)) with cfg(unix)

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -535,10 +535,10 @@ impl Parser {
     #[doc(alias = "ts_parser_print_dot_graphs")]
     pub fn print_dot_graphs(
         &mut self,
-        #[cfg(not(windows))] file: &impl AsRawFd,
+        #[cfg(unix)] file: &impl AsRawFd,
         #[cfg(windows)] file: &impl AsRawHandle,
     ) {
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         {
             let fd = file.as_raw_fd();
             unsafe {


### PR DESCRIPTION
AsRawFd is not available on wasm and cfg(not(windows)) includes wasm